### PR TITLE
Add support for nested types (list, map, struct)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Use Jujutsu (`jj`) for version control.
 - Look out for potential memory leaks. Ensure to use `errdefer` to free allocated memory in an error condition.
 - Make sure to look out for double-free errors, and again use `errdefer` when needed to clean up resources.
 - Use arena allocator to scope allocations, for example in the row group reader, allocate all data page in an arena and free all together.
+- Don't add comments unless they are absolutely necessary - only add them if there is something unusual or non-obvious.
 
 ## Addressing PR feedback
 Each change you make will go through a code review process on GitHub. To address feedback, you can run: 

--- a/src/parquet.zig
+++ b/src/parquet.zig
@@ -1,4 +1,5 @@
 pub const File = @import("parquet/File.zig");
+pub const nestedReader = @import("parquet/nestedReader.zig");
 
 test {
     _ = File;

--- a/src/parquet/File.zig
+++ b/src/parquet/File.zig
@@ -39,6 +39,10 @@ pub const RowGroup = struct {
         return nestedReader.readMap(K, V, self.file, &self.rg.columns[key_index], &self.rg.columns[value_index]);
     }
 
+    pub fn readStructColumn(self: *RowGroup, comptime T: type, base_index: usize) ![]T {
+        return nestedReader.readStruct(T, self.file, self.rg.columns, base_index, @intCast(self.rg.num_rows));
+    }
+
     pub fn readColumnDynamic(self: *RowGroup, index: usize) !dynamic.Values {
         return dynamic.readColumn(self.file, &self.rg.columns[index]);
     }

--- a/src/parquet/File.zig
+++ b/src/parquet/File.zig
@@ -9,6 +9,7 @@ const protocol_compact = @import("../thrift.zig").protocol_compact;
 const dynamic = @import("./dynamic.zig");
 const physical = @import("./physical.zig");
 const rowGroupReader = @import("./rowGroupReader.zig");
+const nestedReader = @import("./nestedReader.zig");
 
 const File = @This();
 
@@ -28,6 +29,10 @@ pub const RowGroup = struct {
 
     pub fn readColumn(self: *RowGroup, comptime T: type, index: usize) ![]T {
         return rowGroupReader.readColumn(T, self.file, &self.rg.columns[index]);
+    }
+
+    pub fn readListColumn(self: *RowGroup, comptime T: type, index: usize) ![][]const T {
+        return nestedReader.readList(T, self.file, &self.rg.columns[index]);
     }
 
     pub fn readColumnDynamic(self: *RowGroup, index: usize) !dynamic.Values {
@@ -79,7 +84,9 @@ pub fn deinit(self: *File) void {
     self.arena.deinit();
 }
 
-pub fn findSchemaElement(self: *File, path: [][]const u8) ?std.meta.Tuple(&[_]type{ u8, u8, parquet_schema.SchemaElement }) {
+/// Find a schema element by path and return its index, definition level, repetition level, and the element itself.
+/// Returns null if the path is not found or invalid.
+pub fn findSchemaElement(self: *File, path: [][]const u8) ?struct { index: usize, max_definition_level: u8, max_repetition_level: u8, elem: parquet_schema.SchemaElement } {
     if (path.len == 0 or self.metadata.schema.len < 2) {
         return null;
     }
@@ -135,33 +142,29 @@ pub fn findSchemaElement(self: *File, path: [][]const u8) ?std.meta.Tuple(&[_]ty
         current_idx = found_idx + 1;
     }
 
-    return .{ max_definition_level, max_repetition_level, elem };
+    return .{ .index = current_idx - 1, .max_definition_level = max_definition_level, .max_repetition_level = max_repetition_level, .elem = elem };
 }
 
-pub fn readLevelDataV1(self: *File, reader: *Reader, encoding: parquet_schema.Encoding, bit_width: u8, num_values: usize) ![]u16 {
-    const values = try self.arena.allocator().alloc(u16, num_values);
+pub fn readLevelDataV1(_: *File, reader: *Reader, encoding: parquet_schema.Encoding, bit_width: u8, dest: []u16) !void {
     switch (encoding) {
         .BIT_PACKED => {
-            try physical.bitPacked(u16, reader, bit_width, values);
+            try physical.bitPacked(u16, reader, bit_width, dest);
         },
         .RLE => {
-            try physical.runLengthBitPackedHybridLengthPrepended(u16, reader, bit_width, values);
+            try physical.runLengthBitPackedHybridLengthPrepended(u16, reader, bit_width, dest);
         },
         else => {
             std.debug.print("Unsupported repetition/definition level encoding: {any}\n", .{encoding});
             return error.UnsupportedDefinitionLevelEncoding;
         },
     }
-    return values;
 }
 
-pub fn readLevelDataV2(self: *File, reader: *Reader, bit_width: u8, num_values: usize, length: u32) ![]u16 {
+pub fn readLevelDataV2(_: *File, reader: *Reader, bit_width: u8, dest: []u16, length: u32) !void {
     var reader_buf: [1024]u8 = undefined;
     var limited_reader = reader.limited(.limited(length), &reader_buf);
 
-    const values = try self.arena.allocator().alloc(u16, num_values);
-    try physical.runLengthBitPackedHybrid(u16, &limited_reader.interface, bit_width, values);
-    return values;
+    try physical.runLengthBitPackedHybrid(u16, &limited_reader.interface, bit_width, dest);
 }
 
 test {

--- a/src/parquet/File.zig
+++ b/src/parquet/File.zig
@@ -35,6 +35,10 @@ pub const RowGroup = struct {
         return nestedReader.readList(T, self.file, &self.rg.columns[index]);
     }
 
+    pub fn readMapColumn(self: *RowGroup, comptime K: type, comptime V: type, key_index: usize, value_index: usize) ![][]const nestedReader.MapEntry(K, V) {
+        return nestedReader.readMap(K, V, self.file, &self.rg.columns[key_index], &self.rg.columns[value_index]);
+    }
+
     pub fn readColumnDynamic(self: *RowGroup, index: usize) !dynamic.Values {
         return dynamic.readColumn(self.file, &self.rg.columns[index]);
     }

--- a/src/parquet/dynamic.zig
+++ b/src/parquet/dynamic.zig
@@ -29,8 +29,8 @@ pub fn readColumn(file: *File, column: *parquet_schema.ColumnChunk) !Values {
         .DOUBLE => .{ .double = try readColumnComptime(?f64, file, column) },
         .BYTE_ARRAY => .{ .byte_array = try readColumnComptime(?[]u8, file, column) },
         .FIXED_LEN_BYTE_ARRAY => {
-            _, _, const schema = file.findSchemaElement(metadata.path_in_schema) orelse return error.MissingSchemaElement;
-            const type_length = schema.type_length orelse return error.MissingTypeLength;
+            const schema_info = file.findSchemaElement(metadata.path_in_schema) orelse return error.MissingSchemaElement;
+            const type_length = schema_info.elem.type_length orelse return error.MissingTypeLength;
 
             return switch (type_length) {
                 2 => .{ .fixed_len_byte_array_2 = try readColumnComptime(?[2]u8, file, column) },

--- a/src/parquet/nestedReader.zig
+++ b/src/parquet/nestedReader.zig
@@ -2,6 +2,65 @@ const parquet_schema = @import("../generated/parquet.zig");
 const File = @import("./File.zig");
 const rowGroupReader = @import("./rowGroupReader.zig");
 
+pub fn MapEntry(comptime K: type, comptime V: type) type {
+    return struct {
+        key: K,
+        value: V,
+    };
+}
+
+pub fn readMap(
+    comptime K: type,
+    comptime V: type,
+    file: *File,
+    key_column: *parquet_schema.ColumnChunk,
+    value_column: *parquet_schema.ColumnChunk,
+) ![][]const MapEntry(K, V) {
+    const arena = file.arena.allocator();
+    const Entry = MapEntry(K, V);
+
+    const key_data = try rowGroupReader.readColumnWithLevels(K, file, key_column);
+    const value_data = try rowGroupReader.readColumnWithLevels(V, file, value_column);
+
+    const key_metadata = key_column.meta_data orelse return error.MissingColumnMetadata;
+    const key_schema_info = file.findSchemaElement(key_metadata.path_in_schema) orelse return error.UnknownField;
+    if (key_schema_info.max_repetition_level == 0) {
+        return error.NotAMapColumn;
+    }
+
+    const rep_levels = key_data.rep_levels orelse return error.MissingRepetitionLevels;
+    var num_maps: usize = 0;
+    for (rep_levels) |rep_level| {
+        if (rep_level == 0) num_maps += 1;
+    }
+
+    const maps = try arena.alloc([]const Entry, num_maps);
+    var map_data = try arena.alloc(Entry, key_data.values.len);
+    var map_data_pos: usize = 0;
+    var map_idx: usize = 0;
+    var map_start: usize = 0;
+
+    for (rep_levels, 0..) |rep_level, i| {
+        if (rep_level == 0 and i > 0) {
+            maps[map_idx] = map_data[map_start..map_data_pos];
+            map_idx += 1;
+            map_start = map_data_pos;
+        }
+
+        map_data[map_data_pos] = .{
+            .key = key_data.values[map_data_pos],
+            .value = value_data.values[map_data_pos],
+        };
+        map_data_pos += 1;
+    }
+
+    if (map_idx < num_maps) {
+        maps[map_idx] = map_data[map_start..map_data_pos];
+    }
+
+    return maps;
+}
+
 pub fn readList(
     comptime T: type,
     file: *File,
@@ -16,7 +75,6 @@ pub fn readList(
     const metadata = column.meta_data orelse return error.MissingColumnMetadata;
     const schema_info = file.findSchemaElement(metadata.path_in_schema) orelse return error.UnknownField;
     const max_def_level = schema_info.max_definition_level;
-
     if (schema_info.max_repetition_level == 0) {
         return error.NotAListColumn;
     }

--- a/src/parquet_testing.zig
+++ b/src/parquet_testing.zig
@@ -566,8 +566,14 @@ test "datapage v2 snappy compressed" {
     try testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3, 4, 5 }, try rg.readColumn(i32, 1));
     try testing.expectEqualSlices(f64, &[_]f64{ 2.0, 3.0, 4.0, 5.0, 2.0 }, try rg.readColumn(f64, 2));
     try testing.expectEqualSlices(bool, &[_]bool{ true, true, true, false, true }, try rg.readColumn(bool, 3));
-    // TODO: Need to unflatten the array once we handle repetition levels: [1, 2, 3], null, null, [1, 2, 3], [1, 2]
-    try testing.expectEqualSlices(?i32, &[_]?i32{ 1, 2, 3, null, null, 1, 2, 3, 1, 2 }, try rg.readColumn(?i32, 4));
+    // e: [[1, 2, 3], null, null, [1, 2, 3], [1, 2]]
+    const e_list = try rg.readListColumn(?i32, 4);
+    try testing.expectEqual(5, e_list.len);
+    try testing.expectEqualDeep(&[_]?i32{ 1, 2, 3 }, e_list[0]);
+    try testing.expectEqual(0, e_list[1].len); // null list represented as empty
+    try testing.expectEqual(0, e_list[2].len); // null list represented as empty
+    try testing.expectEqualDeep(&[_]?i32{ 1, 2, 3 }, e_list[3]);
+    try testing.expectEqualDeep(&[_]?i32{ 1, 2 }, e_list[4]);
 }
 
 test "int32 decimal" {
@@ -866,7 +872,16 @@ test "map no value" {
     try testing.expectEqual(1, file.metadata.row_groups.len);
     try testing.expectEqual(3, file.metadata.num_rows);
 
-    // TODO: Assert fields once we handle repetition levels
+    var rg = file.rowGroup(0);
+
+    // my_map.key_value.key - all map keys flattened
+    try testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8, 9 }, try rg.readColumn(i32, 0));
+    // my_map.key_value.value - all null values
+    try testing.expectEqualSlices(?i32, &[_]?i32{ null, null, null, null, null, null, null, null, null }, try rg.readColumn(?i32, 1));
+    // my_map_no_v.key_value.key
+    try testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8, 9 }, try rg.readColumn(i32, 2));
+    // my_list.list.element
+    try testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3, 4, 5, 6, 7, 8, 9 }, try rg.readColumn(i32, 3));
 }
 
 test "nation dict malformed" {
@@ -894,6 +909,16 @@ test "nested structs rust" {
 
     try testing.expectEqual(1, file.metadata.row_groups.len);
     try testing.expectEqual(1, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+
+    // roll_num struct fields (columns 0-5)
+    try testing.expectEqualSlices(i64, &[_]i64{190406409000602}, try rg.readColumn(i64, 0)); // min
+    try testing.expectEqualSlices(i64, &[_]i64{190407175004000}, try rg.readColumn(i64, 1)); // max
+    try testing.expectEqualSlices(i64, &[_]i64{190406671229999}, try rg.readColumn(i64, 2)); // mean
+    try testing.expectEqualSlices(i64, &[_]i64{495}, try rg.readColumn(i64, 3)); // count
+    try testing.expectEqualSlices(i64, &[_]i64{94251302258849568}, try rg.readColumn(i64, 4)); // sum
+    try testing.expectEqualSlices(i64, &[_]i64{0}, try rg.readColumn(i64, 5)); // variance
 }
 
 test "non-nullable impala" {
@@ -904,6 +929,21 @@ test "non-nullable impala" {
 
     try testing.expectEqual(1, file.metadata.row_groups.len);
     try testing.expectEqual(1, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+
+    // ID
+    try testing.expectEqualSlices(i64, &[_]i64{8}, try rg.readColumn(i64, 0));
+    // Int_Array.list.element
+    try testing.expectEqualSlices(i32, &[_]i32{-1}, try rg.readColumn(i32, 1));
+    // Int_Map.map.key
+    try testing.expectEqualDeep(&[_][]const u8{"k1"}, try rg.readColumn([]const u8, 3));
+    // Int_Map.map.value
+    try testing.expectEqualSlices(i32, &[_]i32{-1}, try rg.readColumn(i32, 4));
+    // nested_Struct.a
+    try testing.expectEqualSlices(i32, &[_]i32{-1}, try rg.readColumn(i32, 7));
+    // nested_Struct.B.list.element
+    try testing.expectEqualSlices(i32, &[_]i32{-1}, try rg.readColumn(i32, 8));
 }
 
 test "nulls snappy" {
@@ -1085,4 +1125,50 @@ test "byte stream split extended gzip" {
         [_]u8{ 48, 51, 49, 50, 53 }, // "03125"
     };
     try testing.expectEqualSlices([5]u8, &expected_flba5, flba5_plain[0..5]);
+}
+
+test "list columns" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/list_columns.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(3, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+
+    // int64_list: [[1, 2, 3], [null, 1], [4]]
+    const int_lists = try rg.readListColumn(?i64, 0);
+    try testing.expectEqual(3, int_lists.len);
+    try testing.expectEqualDeep(&[_]?i64{ 1, 2, 3 }, int_lists[0]);
+    try testing.expectEqualDeep(&[_]?i64{ null, 1 }, int_lists[1]);
+    try testing.expectEqualDeep(&[_]?i64{4}, int_lists[2]);
+
+    // utf8_list: [["abc", "efg", "hij"], null, ["efg", null, "hij", "xyz"]]
+    const string_lists = try rg.readListColumn(?[]const u8, 1);
+    try testing.expectEqual(3, string_lists.len);
+    try testing.expectEqualDeep(&[_]?[]const u8{ "abc", "efg", "hij" }, string_lists[0]);
+    try testing.expectEqual(0, string_lists[1].len); // null list represented as empty
+    try testing.expectEqualDeep(&[_]?[]const u8{ "efg", null, "hij", "xyz" }, string_lists[2]);
+}
+
+test "repeated no annotation" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/repeated_no_annotation.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    // Note: num_rows in metadata is 0, but actual data has 6 rows
+    try testing.expectEqual(0, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+
+    // id column
+    try testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3, 4, 5, 6 }, try rg.readColumn(i32, 0));
+    // phoneNumbers.phone.number - flattened phone numbers
+    try testing.expectEqualSlices(?i64, &[_]?i64{ null, null, null, 5555555555, 1111111111, 1111111111, 2222222222, 3333333333 }, try rg.readColumn(?i64, 1));
+    // phoneNumbers.phone.kind - flattened phone kinds
+    try testing.expectEqualDeep(&[_]?[]const u8{ null, null, null, null, "home", "home", null, "mobile" }, try rg.readColumn(?[]const u8, 2));
 }

--- a/src/parquet_testing.zig
+++ b/src/parquet_testing.zig
@@ -931,13 +931,25 @@ test "nested structs rust" {
 
     var rg = file.rowGroup(0);
 
-    // roll_num struct fields (columns 0-5)
-    try testing.expectEqualSlices(i64, &[_]i64{190406409000602}, try rg.readColumn(i64, 0)); // min
-    try testing.expectEqualSlices(i64, &[_]i64{190407175004000}, try rg.readColumn(i64, 1)); // max
-    try testing.expectEqualSlices(i64, &[_]i64{190406671229999}, try rg.readColumn(i64, 2)); // mean
-    try testing.expectEqualSlices(i64, &[_]i64{495}, try rg.readColumn(i64, 3)); // count
-    try testing.expectEqualSlices(i64, &[_]i64{94251302258849568}, try rg.readColumn(i64, 4)); // sum
-    try testing.expectEqualSlices(i64, &[_]i64{0}, try rg.readColumn(i64, 5)); // variance
+    // roll_num struct (columns 0-5): {min, max, mean, count, sum, variance}
+    const RollNum = struct {
+        min: i64,
+        max: i64,
+        mean: i64,
+        count: i64,
+        sum: i64,
+        variance: i64,
+    };
+    const roll_num = try rg.readStructColumn(RollNum, 0);
+    try testing.expectEqual(1, roll_num.len);
+    try testing.expectEqual(RollNum{
+        .min = 190406409000602,
+        .max = 190407175004000,
+        .mean = 190406671229999,
+        .count = 495,
+        .sum = 94251302258849568,
+        .variance = 0,
+    }, roll_num[0]);
 }
 
 test "non-nullable impala" {


### PR DESCRIPTION
## Summary

This PR implements Dremel-based nested data reconstruction for parzig:

- Refactored level reading to avoid unnecessary allocations and improve performance
- Added `nestedReader` module with support for list, map, and struct columns
- Updated `File.zig` to expose nested column readers (`readListColumn`, `readMapColumn`, `readStructColumn`)
- Fixed definition/repetition level handling in `rowGroupReader` to properly track levels across pages
- Added comprehensive tests for nested structures in parquet-testing suite

## Supported Features

✅ Basic list columns with nullable elements  
✅ Map columns with key-value pairs  
✅ Struct columns with multiple fields  
✅ Repeated fields with and without list annotation  
✅ Proper definition and repetition level reconstruction  

## Known Limitations

The implementation now passes most nested type test files, but some deeply nested structures still have issues:
- Multi-level nested lists (list<list<T>>) parse but may return incorrect null values
- Nested map values (map<K, map<K2, V2>>) can fail with RLE decoder errors

## Test Coverage

Updated `TESTING.md` to reflect the new support - 7 additional files now passing with nested type support.

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>