### PR TITLE
Add Claude remote setup script with SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_pkgs_on_remote.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/install_pkgs_on_remote.sh
+++ b/scripts/install_pkgs_on_remote.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Only run in remote environments
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+echo "Installing jj using Cargo..."
+cargo install --locked --bin jj jj-cli
+jj --version
+
+echo "Installing uv using pipx..."
+pipx install uv
+uv --version
+
+echo "Installing anyzig..."
+arch=$(uname -m)
+if [[ $arch == x86_64* ]]; then
+    curl -L https://github.com/marler8997/anyzig/releases/latest/download/anyzig-x86_64-linux.tar.gz | tar xz
+elif [[ $arch == aarch64* ]]; then
+    curl -L https://github.com/marler8997/anyzig/releases/latest/download/anyzig-aarch64-linux.tar.gz | tar xz
+fi
+mv ./zig /usr/local/bin
+zig any version
+zig version
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook in `.claude/settings.json` that automatically runs the setup script when starting a remote Claude VM session
- Creates `scripts/install_pkgs_on_remote.sh` to install required dependencies (jj, uv, Zig via anyzig)
- Uses `uname -m` for reliable architecture detection on Linux
- Only runs in remote environments (checks `$CLAUDE_CODE_REMOTE`)

## Test plan
- [ ] Test on remote VM that the hook executes on session start
- [ ] Verify jj, uv, and Zig are installed correctly
- [ ] Verify architecture detection works on both x86_64 and aarch64 Linux systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)