### PR TITLE
Fix parsing of dict-page-offset-zero.parquet

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -28,7 +28,7 @@ parzig includes parquet-testing as a submodule in [`./testdata/parquet-testing`]
 | `delta_encoding_optional_column.parquet`         | ✅     |                           |
 | `delta_encoding_required_column.parquet`         | ✅     |                           |
 | `delta_length_byte_array.parquet`                | ✅     |                           |
-| `dict-page-offset-zero.parquet`                  | 🚧     | Thrift parsing error      |
+| `dict-page-offset-zero.parquet`                  | ✅     |                           |
 | `fixed_length_byte_array.parquet`                | 🚧     | Malformed file            |
 | `fixed_length_decimal.parquet`                   | ✅     |                           |
 | `fixed_length_decimal_legacy.parquet`            | ✅     |                           |
@@ -72,11 +72,6 @@ parzig includes parquet-testing as a submodule in [`./testdata/parquet-testing`]
 The failing tests (🚧) can be grouped into the following categories:
 
 ### Files with Special Issues
-
-#### `dict-page-offset-zero.parquet`
-- **parzig**: Thrift metadata parsing error (UnexpectedList in compact protocol)
-- **Pandas/PyArrow**: Can read successfully (39 rows, all values are 1552)
-- **Status**: Issue is in parzig's Thrift decoder, not the file itself
 
 #### `fixed_length_byte_array.parquet`
 - **parzig**: Unsupported fixed-length size (11 bytes)

--- a/src/parquet_testing.zig
+++ b/src/parquet_testing.zig
@@ -1212,3 +1212,18 @@ test "repeated no annotation" {
     // phoneNumbers.phone.kind - flattened phone kinds
     try testing.expectEqualDeep(&[_]?[]const u8{ null, null, null, null, "home", "home", null, "mobile" }, try rg.readColumn(?[]const u8, 2));
 }
+
+test "dict page offset zero" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/dict-page-offset-zero.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(39, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+
+    const expected = [_]?i32{1552} ** 39;
+    try testing.expectEqualSlices(?i32, &expected, try rg.readColumn(?i32, 0));
+}


### PR DESCRIPTION
## Summary

This PR fixes the parsing of `dict-page-offset-zero.parquet` by addressing two issues:

### 1. Thrift type mismatch handling

The file was created with an older version of parquet-mr (1.12.0) that wrote a `list` at field 15 of `ColumnMetaData`. However, the current Parquet spec has field 15 as `bloom_filter_length: optional i32`. This caused parzig's Thrift decoder to fail with `UnexpectedList`.

**Fix**: Added a `skipField()` function inside `StructReader` that can skip any Thrift field type. Modified the reader to skip fields with unknown IDs or type mismatches instead of returning errors.

### 2. dictionary_page_offset=0 handling

The file has `dictionary_page_offset=0`, which was being interpreted as "dictionary page at offset 0". However, offset 0 is where the PAR1 magic bytes are, so it's used as a sentinel for "no dictionary page".

**Fix**: Added a check to treat `dictionary_page_offset=0` as no dictionary page.

## Changes

- `src/thrift/protocol/compact.zig`: Added `skipField()` function and modified `StructReader` to skip unknown/mismatched fields
- `src/parquet/rowGroupReader.zig`: Treat `dictionary_page_offset=0` as no dictionary
- `src/parquet_testing.zig`: Added conformance test
- `TESTING.md`: Updated status from 🚧 to ✅