### PR TITLE
Add Decimal logical type support

### DIFF
--- a/src/parquet.zig
+++ b/src/parquet.zig
@@ -21,6 +21,7 @@ pub const UInt16 = logical.UInt16;
 pub const UInt32 = logical.UInt32;
 pub const UInt64 = logical.UInt64;
 pub const Float16 = logical.Float16;
+pub const Decimal = logical.Decimal;
 
 test {
     _ = File;

--- a/src/parquet/dynamic.zig
+++ b/src/parquet/dynamic.zig
@@ -11,10 +11,22 @@ pub const Values = union(enum) {
     float: []?f32,
     double: []?f64,
     byte_array: []?[]u8,
+    fixed_len_byte_array_1: []?[1]u8,
     fixed_len_byte_array_2: []?[2]u8,
+    fixed_len_byte_array_3: []?[3]u8,
     fixed_len_byte_array_4: []?[4]u8,
+    fixed_len_byte_array_5: []?[5]u8,
     fixed_len_byte_array_6: []?[6]u8,
+    fixed_len_byte_array_7: []?[7]u8,
     fixed_len_byte_array_8: []?[8]u8,
+    fixed_len_byte_array_9: []?[9]u8,
+    fixed_len_byte_array_10: []?[10]u8,
+    fixed_len_byte_array_11: []?[11]u8,
+    fixed_len_byte_array_12: []?[12]u8,
+    fixed_len_byte_array_13: []?[13]u8,
+    fixed_len_byte_array_14: []?[14]u8,
+    fixed_len_byte_array_15: []?[15]u8,
+    fixed_len_byte_array_16: []?[16]u8,
 };
 
 pub fn readColumn(file: *File, column: *parquet_schema.ColumnChunk) !Values {
@@ -33,10 +45,9 @@ pub fn readColumn(file: *File, column: *parquet_schema.ColumnChunk) !Values {
             const type_length = schema_info.elem.type_length orelse return error.MissingTypeLength;
 
             return switch (type_length) {
-                2 => .{ .fixed_len_byte_array_2 = try readColumnComptime(?[2]u8, file, column) },
-                4 => .{ .fixed_len_byte_array_4 = try readColumnComptime(?[4]u8, file, column) },
-                6 => .{ .fixed_len_byte_array_6 = try readColumnComptime(?[6]u8, file, column) },
-                8 => .{ .fixed_len_byte_array_8 = try readColumnComptime(?[8]u8, file, column) },
+                inline 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 => |len| {
+                    return @unionInit(Values, std.fmt.comptimePrint("fixed_len_byte_array_{d}", .{len}), try readColumnComptime(?[len]u8, file, column));
+                },
                 else => {
                     std.debug.print("Unsupported type length for `FIXED_LEN_BYTE_ARRAY`: {d}\n", .{type_length});
                     return error.UnsupportedFixedLength;

--- a/src/parquet_testing.zig
+++ b/src/parquet_testing.zig
@@ -148,7 +148,7 @@ test "binary data" {
     }, try rg.readColumn([]const u8, 0));
 }
 
-test "byte array decimal" {
+test "byte array decimal raw" {
     var reader_buf: [1024]u8 = undefined;
     var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/byte_array_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
     var file = try File.read(testing.allocator, &file_reader);
@@ -592,7 +592,7 @@ test "datapage v2 snappy compressed" {
     try testing.expectEqualDeep(&[_]?i32{ 1, 2 }, e_list[4]);
 }
 
-test "int32 decimal" {
+test "int32 decimal raw" {
     var reader_buf: [1024]u8 = undefined;
     var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/int32_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
     var file = try File.read(testing.allocator, &file_reader);
@@ -641,7 +641,7 @@ test "int32 with null pages" {
     try testing.expectEqual(@as(?i32, 370689415), values[19]);
 }
 
-test "int64 decimal" {
+test "int64 decimal raw" {
     var reader_buf: [1024]u8 = undefined;
     var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/int64_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
     var file = try File.read(testing.allocator, &file_reader);
@@ -1091,7 +1091,7 @@ test "data index bloom encoding with length" {
     try testing.expectEqualDeep(&[_][]const u8{ "Hello", "This is", "a", "test", "How", "are you", "doing ", "today", "the quick", "brown fox", "jumps", "over", "the lazy", "dog" }, try rg.readColumn([]const u8, 0));
 }
 
-test "fixed length decimal" {
+test "fixed length decimal raw" {
     var reader_buf: [1024]u8 = undefined;
     var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/fixed_length_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
     var file = try File.read(testing.allocator, &file_reader);
@@ -1241,4 +1241,72 @@ test "dict page offset zero" {
 
     const expected = [_]?i32{1552} ** 39;
     try testing.expectEqualSlices(?i32, &expected, try rg.readColumn(?i32, 0));
+}
+
+test "int32 decimal" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/int32_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(24, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+    const values = try rg.readColumn(parzig.parquet.Decimal, 0);
+
+    try testing.expectEqual(24, values.len);
+    try testing.expectEqual(@as(f128, 1.0), values[0].value);
+    try testing.expectEqual(@as(f128, 24.0), values[23].value);
+}
+
+test "int64 decimal" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/int64_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(24, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+    const values = try rg.readColumn(parzig.parquet.Decimal, 0);
+
+    try testing.expectEqual(24, values.len);
+    try testing.expectEqual(@as(f128, 1.0), values[0].value);
+    try testing.expectEqual(@as(f128, 24.0), values[23].value);
+}
+
+test "byte array decimal" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/byte_array_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(24, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+    const values = try rg.readColumn(parzig.parquet.Decimal, 0);
+
+    try testing.expectEqual(24, values.len);
+    try testing.expectEqual(@as(f128, 1.0), values[0].value);
+    try testing.expectEqual(@as(f128, 24.0), values[23].value);
+}
+
+test "fixed length decimal" {
+    var reader_buf: [1024]u8 = undefined;
+    var file_reader = (try Io.Dir.cwd().openFile(io, "testdata/parquet-testing/data/fixed_length_decimal.parquet", .{ .mode = .read_only })).reader(io, &reader_buf);
+    var file = try File.read(testing.allocator, &file_reader);
+    defer file.deinit();
+
+    try testing.expectEqual(1, file.metadata.row_groups.len);
+    try testing.expectEqual(24, file.metadata.num_rows);
+
+    var rg = file.rowGroup(0);
+    const values = try rg.readColumn(parzig.parquet.Decimal, 0);
+
+    try testing.expectEqual(24, values.len);
+    try testing.expectEqual(@as(f128, 1.0), values[0].value);
+    try testing.expectEqual(@as(f128, 24.0), values[23].value);
 }


### PR DESCRIPTION
## Summary
- Add `Decimal` logical type with f128 storage for high precision (~33-36 decimal digits)
- Support all four physical type variants: INT32, INT64, BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY (1-16 bytes)
- Extend dynamic reader to support fixed-length byte arrays 1-16 bytes
- Add conformance tests for all decimal physical types

## Test plan
- [x] `zig build test` passes
- [x] int32_decimal.parquet conformance test
- [x] int64_decimal.parquet conformance test
- [x] byte_array_decimal.parquet conformance test
- [x] fixed_length_decimal.parquet conformance test

🤖 Generated with [Claude Code](https://claude.ai/code)