### PR TITLE
Update Zig to 0.16.0-dev.2261+d6b3dd25a

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .parzig,
     .version = "0.0.0",
-    .minimum_zig_version = "0.16.0-dev.1859+212968c57",
+    .minimum_zig_version = "0.16.0-dev.2261+d6b3dd25a",
     .fingerprint = 0xe10b531b76c12ef9,
     .dependencies = .{},
     .paths = .{

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -3,14 +3,14 @@ const parzig = @import("parzig");
 
 const Io = std.Io;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer {
         std.debug.assert(gpa.deinit() == .ok);
     }
     const allocator = gpa.allocator();
 
-    var threaded: Io.Threaded = .init(allocator, .{});
+    var threaded: Io.Threaded = .init(allocator, .{ .environ = init.environ });
     defer threaded.deinit();
     const io = threaded.io();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,19 +3,19 @@ const parzig = @import("parzig");
 
 const Io = std.Io;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer {
         std.debug.assert(gpa.deinit() == .ok);
     }
     const allocator = gpa.allocator();
 
-    var args = std.process.args();
-    _ = args.next() orelse unreachable; // program name
+    var args = std.process.Args.Iterator.init(init.args);
+    _ = args.skip(); // program name
     const path = args.next() orelse return error.MissingArgument;
     std.debug.print("Parsing {s}\n", .{path});
 
-    var threaded: Io.Threaded = .init(allocator, .{});
+    var threaded: Io.Threaded = .init(allocator, .{ .environ = init.environ });
     defer threaded.deinit();
     const io = threaded.io();
 
@@ -63,10 +63,22 @@ pub fn main() !void {
                 .float => |data| printValues(f32, data),
                 .double => |data| printValues(f64, data),
                 .byte_array => |data| printValues([]u8, data),
+                .fixed_len_byte_array_1 => |data| printValues([1]u8, data),
                 .fixed_len_byte_array_2 => |data| printValues([2]u8, data),
+                .fixed_len_byte_array_3 => |data| printValues([3]u8, data),
                 .fixed_len_byte_array_4 => |data| printValues([4]u8, data),
+                .fixed_len_byte_array_5 => |data| printValues([5]u8, data),
                 .fixed_len_byte_array_6 => |data| printValues([6]u8, data),
+                .fixed_len_byte_array_7 => |data| printValues([7]u8, data),
                 .fixed_len_byte_array_8 => |data| printValues([8]u8, data),
+                .fixed_len_byte_array_9 => |data| printValues([9]u8, data),
+                .fixed_len_byte_array_10 => |data| printValues([10]u8, data),
+                .fixed_len_byte_array_11 => |data| printValues([11]u8, data),
+                .fixed_len_byte_array_12 => |data| printValues([12]u8, data),
+                .fixed_len_byte_array_13 => |data| printValues([13]u8, data),
+                .fixed_len_byte_array_14 => |data| printValues([14]u8, data),
+                .fixed_len_byte_array_15 => |data| printValues([15]u8, data),
+                .fixed_len_byte_array_16 => |data| printValues([16]u8, data),
             }
         }
     }


### PR DESCRIPTION
## Summary
- Update minimum_zig_version in build.zig.zon to 0.16.0-dev.2261+d6b3dd25a
- Adapt main functions to new `std.process.Init.Minimal` API
- Pass `environ` to `Io.Threaded.init` (now required)
- Use `Args.Iterator` for command line argument parsing
- Add missing switch cases for fixed_len_byte_array types 1,3,5,7,9-16

## Test plan
- [x] `zig build` succeeds
- [x] `zig build test` passes
- [x] `zig build run -- ./testdata/parquet-testing/data/byte_stream_split_extended.gzip.parquet` works

🤖 Generated with [Claude Code](https://claude.ai/code)