### PR TITLE
Refactor findSchemaElement to use named struct and add column_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pub fn main(init: std.process.Init) !void {
 }
 
 fn columnIndex(file: *File, name: []const u8) usize {
-    return file.findSchemaElement(&.{name}).?.index - 1;
+    return file.findSchemaElement(&.{name}).?.column_index;
 }
 ```
 

--- a/examples/nyc_taxi.zig
+++ b/examples/nyc_taxi.zig
@@ -46,5 +46,5 @@ pub fn main(init: std.process.Init) !void {
 }
 
 fn columnIndex(file: *File, name: []const u8) usize {
-    return file.findSchemaElement(&.{name}).?.index - 1;
+    return file.findSchemaElement(&.{name}).?.column_index;
 }


### PR DESCRIPTION
## Summary

**Problem:** The `findSchemaElement` method returned a schema index that required users to subtract 1 to get the column index (as seen in the NYC taxi example: `file.findSchemaElement(&.{name}).?.index - 1`).

**Solution:**

- **Define a named struct `SchemaInfo`** instead of anonymous struct with fields:
  - `column_index` - index into the row group's columns array (leaf elements only)
  - `max_definition_level` - for handling nullability
  - `max_repetition_level` - for handling repeated elements
  - `elem` - the schema element itself

- **Update `findSchemaElement`** to track the column index by counting only leaf elements (elements without children) as it traverses the schema tree.

- **Update the NYC taxi example and README** to use `column_index` directly instead of `index - 1`.

- **Add tests** for:
  - Flat schema: verifies column indices 0, 1, 2 for columns foo, bar, ham
  - Non-existent paths: verifies null is returned
  - Optional columns: verifies correct definition/repetition levels
  - Nested schema: verifies correct column indices for nested struct fields (e.g., `roll_num.min` → 0, `roll_num.variance` → 5, `PC_CUR.min` → 6)