### PR TITLE
Fix Snappy decompressor buffer corruption and add ClickBench tests

### DIFF
--- a/scripts/download-public-datasets.sh
+++ b/scripts/download-public-datasets.sh
@@ -54,6 +54,28 @@ download_nyc_taxi() {
 }
 
 # =============================================================================
+# ClickBench Dataset
+# Source: https://github.com/ClickHouse/ClickBench
+# =============================================================================
+download_clickbench() {
+    local mode="$1"
+    local base_url="https://datasets.clickhouse.com/hits_compatible/athena_partitioned"
+    local dest="$DEST_DIR/clickbench"
+    mkdir -p "$dest"
+
+    echo "=== ClickBench Dataset ==="
+
+    if [[ "$mode" == "all" ]]; then
+        echo "Downloading ClickBench partitioned files (CI only)..."
+        for i in 0 1 2; do
+            download_file "$base_url/hits_$i.parquet" "$dest/hits_$i.parquet"
+        done
+    else
+        echo "Skipping ClickBench (CI only, use --all to download)"
+    fi
+}
+
+# =============================================================================
 # Add more datasets here following the same pattern
 # =============================================================================
 
@@ -93,6 +115,7 @@ done
 mkdir -p "$DEST_DIR"
 
 download_nyc_taxi "$MODE"
+download_clickbench "$MODE"
 
 echo ""
 echo "Done!"

--- a/src/parquet/rowGroupReader.zig
+++ b/src/parquet/rowGroupReader.zig
@@ -336,7 +336,7 @@ fn decoderForPage(arena: std.mem.Allocator, inner_reader: *Reader, codec: parque
             break :blk &decompress.reader;
         },
         .SNAPPY => blk: {
-            const buf = try arena.alloc(u8, compress.snappy.Decompress.window_len);
+            const buf = try arena.alloc(u8, compress.snappy.Decompress.buffer_len);
             const decompress = try arena.create(compress.snappy.Decompress);
             decompress.* = compress.snappy.Decompress.init(inner_reader, buf);
             break :blk &decompress.reader;

--- a/testdata/public-datasets/README.md
+++ b/testdata/public-datasets/README.md
@@ -12,6 +12,10 @@ public-datasets/
 │   ├── fhv_tripdata_2025-10.parquet
 │   ├── yellow_tripdata_2025-10.parquet (CI only)
 │   └── fhvhv_tripdata_2025-10.parquet (CI only)
+├── clickbench/         # ClickBench web analytics data (CI only)
+│   ├── hits_0.parquet
+│   ├── hits_1.parquet
+│   └── hits_2.parquet
 └── <future-dataset>/   # More datasets can be added
 ```
 
@@ -27,6 +31,20 @@ Source: [TLC Trip Record Data](https://www.nyc.gov/site/tlc/about/tlc-trip-recor
 | `fhv_tripdata_2025-10.parquet` | ~25MB | No |
 | `yellow_tripdata_2025-10.parquet` | ~50MB | Yes |
 | `fhvhv_tripdata_2025-10.parquet` | ~400MB | Yes |
+
+### ClickBench
+
+Source: [ClickHouse/ClickBench](https://github.com/ClickHouse/ClickBench)
+
+Real-world web analytics data with 105 columns covering diverse types. The dataset
+is "intentionally dirty" with no bloom filters or proper logical types, making it
+excellent for stress-testing edge cases.
+
+| File | Size | CI Only |
+|------|------|---------|
+| `hits_0.parquet` | ~150MB | Yes |
+| `hits_1.parquet` | ~150MB | Yes |
+| `hits_2.parquet` | ~150MB | Yes |
 
 ## Download
 


### PR DESCRIPTION
## Summary

Fixes buffer corruption issues in the Snappy decompressor that occurred when processing large files with copy operations.

## Changes

### Snappy Decompressor Fix
- **Root cause**: The decompressor was using the writer's buffer for copy back-references, but this buffer could be invalidated/flushed between writes, causing corruption
- **Fix**: Introduced a dedicated circular window buffer (128KB) that maintains the last bytes for copy operations, independent of the writer's state
- Added proper bounds checking for copy offsets (`copy.offset > d.total_written or copy.offset == 0`)
- Added EOF handling when `remaining == 0` in both literal and copy states
- Added buffer length assertion in `init()`

### ClickBench Conformance Tests
- Added download script for ClickBench partitioned Parquet files (~450MB total, CI only)
- Added conformance test that reads all 3 ClickBench files (105 columns each)
- Updated README with ClickBench dataset documentation

## Testing
- All existing Snappy tests pass
- ClickBench tests exercise the fix with real-world large Snappy-compressed data